### PR TITLE
Remove extra parenthesis from AddOpenApiDocument example

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ dotnet add package ZymLabs.NSwag.FluentValidation
 // This method gets called by the runtime. Use this method to add services to the container.
 public void ConfigureServices(IServiceCollection services)
 {
-    services.AddOpenApiDocument((settings, serviceProvider)) =>
+    services.AddOpenApiDocument((settings, serviceProvider) =>
     {
         var fluentValidationSchemaProcessor = serviceProvider.GetService<FluentValidationSchemaProcessor>();
 


### PR DESCRIPTION
I know, this is the smallest PR you can imagine but the sample code in the readme didn't work with the extra parenthesis.