### PR TITLE
No longer add NotNull/NotEmpty complex type properties as "oneOf"

### DIFF
--- a/src/ZymLabs.NSwag.FluentValidation/FluentValidationSchemaProcessor.cs
+++ b/src/ZymLabs.NSwag.FluentValidation/FluentValidationSchemaProcessor.cs
@@ -192,6 +192,14 @@ namespace ZymLabs.NSwag.FluentValidation
                         {
                             schema.Properties[context.PropertyKey].Type &= ~JsonObjectType.Null; // Remove nullable
                         }
+
+                        var oneOfsWithReference = schema.Properties[context.PropertyKey].OneOf.Where(x => x.Reference != null).ToList();
+                        if (oneOfsWithReference.Count == 1)
+                        {
+                            // Set the Reference directly instead and clear the OneOf collection
+                            schema.Properties[context.PropertyKey].Reference = oneOfsWithReference.Single();
+                            schema.Properties[context.PropertyKey].OneOf.Clear();
+                        }
                     }
                 },
                 new FluentValidationRule("NotEmpty")
@@ -207,7 +215,15 @@ namespace ZymLabs.NSwag.FluentValidation
                         {
                             schema.Properties[context.PropertyKey].Type &= ~JsonObjectType.Null; // Remove nullable
                         }
-                        
+
+                        var oneOfsWithReference = schema.Properties[context.PropertyKey].OneOf.Where(x => x.Reference != null).ToList();
+                        if (oneOfsWithReference.Count == 1)
+                        {
+                            // Set the Reference directly instead and clear the OneOf collection
+                            schema.Properties[context.PropertyKey].Reference = oneOfsWithReference.Single();
+                            schema.Properties[context.PropertyKey].OneOf.Clear();
+                        }
+
                         schema.Properties[context.PropertyKey].MinLength = 1;
                     }
                 },

--- a/tests/ZymLabs.NSwag.FluentValidation.Tests/FluentValidationSchemaProcessorTest.cs
+++ b/tests/ZymLabs.NSwag.FluentValidation.Tests/FluentValidationSchemaProcessorTest.cs
@@ -61,6 +61,10 @@ namespace ZymLabs.NSwag.FluentValidation.Tests
             // Assert
             Assert.Equal(1, schema.Properties["NotEmpty"].MinLength);
             Assert.False(schema.Properties["NotEmpty"].IsNullable(SchemaType.OpenApi3));
+
+            var notEmptyChildProperty = schema.Properties["NotEmptyChild"];
+            Assert.Empty(notEmptyChildProperty.OneOf);
+            Assert.NotNull(notEmptyChildProperty.Reference);
         }
 
         [Fact]
@@ -78,6 +82,10 @@ namespace ZymLabs.NSwag.FluentValidation.Tests
             var test = schema.Properties["NotNull"];
             var value = test.IsNullable(SchemaType.OpenApi3);
             Assert.False(value);
+
+            var notNullChildProperty = schema.Properties["NotNullChild"];
+            Assert.Empty(notNullChildProperty.OneOf);
+            Assert.NotNull(notNullChildProperty.Reference);
         }
 
         [Fact]

--- a/tests/ZymLabs.NSwag.FluentValidation.Tests/MockValidationTarget.cs
+++ b/tests/ZymLabs.NSwag.FluentValidation.Tests/MockValidationTarget.cs
@@ -19,5 +19,13 @@ namespace ZymLabs.NSwag.FluentValidation.Tests
         public double ValueInRangeDouble { get; set; }
 
         public string IncludeField { get; set; }
+
+        public MockValidationTargetChild NotNullChild { get; set; }
+        public MockValidationTargetChild NotEmptyChild { get; set; }
+    }
+
+    public class MockValidationTargetChild
+    {
+        public string ChildProperty { get; set; }
     }
 }

--- a/tests/ZymLabs.NSwag.FluentValidation.Tests/MockValidationTargetValidator.cs
+++ b/tests/ZymLabs.NSwag.FluentValidation.Tests/MockValidationTargetValidator.cs
@@ -22,6 +22,9 @@ namespace ZymLabs.NSwag.FluentValidation.Tests
             RuleFor(sample => sample.ValueInRangeFloat).InclusiveBetween(1.1f, 5.3f);
             RuleFor(sample => sample.ValueInRangeDouble).ExclusiveBetween(2.2, 7.5f);
 
+            RuleFor(sample => sample.NotNullChild).NotNull();
+            RuleFor(sample => sample.NotEmptyChild).NotEmpty();
+
             Include(new MockValidationTargetIncludeValidator());
         }
     }


### PR DESCRIPTION
# NSwag.FluentValidation

When a class has a complex type as a property and a validator sets it as `NotNull()` or `NotEmpty()`, currently a schema property such as below is created:

```json
"complexType": {
	"minLength": 1,
	"nullable": false,
	"oneOf": [{
			"$ref": "#/components/schemas/ComplexType"
		}
	]
}
```

Due to the fact that "oneOf" is used, the "Example Value" shown by Swagger UI doesn't include the property.

With the changes in this PR, the generated swagger.json schema property now looks like this:

```json
"complexType": {
	"minLength": 1,
	"nullable": false,
	"$ref": "#/components/schemas/ComplexType"
}
```

Which no longer uses "oneOf", and therefore results in a correct "Example Value" in Swagger UI and more closely represents the swagger.json that is generated when the `[Required]` attribute is used.