### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ public void ConfigureServices(IServiceCollection services)
     });
 
     // Add the FluentValidationSchemaProcessor as a scoped service
-    serviceCollection.AddScoped<FluentValidationSchemaProcessor>(provider =>
+    services.AddScoped<FluentValidationSchemaProcessor>(provider =>
     {
         var validationRules = provider.GetService<IEnumerable<FluentValidationRule>>();
         var loggerFactory = provider.GetService<ILoggerFactory>();


### PR DESCRIPTION
Fixed the demo typo.

In the demo, service collection was accessed using the field `serviceCollection` which does not exist. It should be `services`.