### PR TITLE
Update for FluentValidation 11 and update targets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 6.0.x
+          dotnet-version: 8.0.x
           source-url: https://nuget.pkg.github.com/zymlabs/index.json
         env:
           NUGET_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
@@ -89,7 +89,7 @@ jobs:
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 6.0.x
+          dotnet-version: 8.0.x
           source-url: https://nuget.pkg.github.com/zymlabs/index.json
         env:
           NUGET_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
@@ -152,7 +152,7 @@ jobs:
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 6.0.x
+          dotnet-version: 8.0.x
           source-url: https://nuget.pkg.github.com/zymlabs/index.json
         env:
           NUGET_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/src/ZymLabs.NSwag.FluentValidation.AspNetCore/HttpContextServiceProviderValidatorFactory.cs
+++ b/src/ZymLabs.NSwag.FluentValidation.AspNetCore/HttpContextServiceProviderValidatorFactory.cs
@@ -24,8 +24,9 @@ namespace ZymLabs.NSwag.FluentValidation.AspNetCore
         /// <inheritdoc/>
         public override IValidator? CreateInstance(Type validatorType)
         {
-            var serviceProvider = _httpContextAccessor.HttpContext.RequestServices;
-            var validator = serviceProvider.GetService(validatorType) as IValidator;
+            var serviceProvider = _httpContextAccessor.HttpContext?.RequestServices;
+
+            var validator = serviceProvider?.GetService(validatorType) as IValidator;
 
             // Returns null when there isn't a validator for the type silently
             // if (validator == null)

--- a/src/ZymLabs.NSwag.FluentValidation.AspNetCore/ZymLabs.NSwag.FluentValidation.AspNetCore.csproj
+++ b/src/ZymLabs.NSwag.FluentValidation.AspNetCore/ZymLabs.NSwag.FluentValidation.AspNetCore.csproj
@@ -1,16 +1,20 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-      <TargetFramework>netstandard2.0</TargetFramework>
+      <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
       <Description>Use FluentValidation rules to define validation requirements for NSwag Swagger/OpenAPI schema.</Description>
-      <Copyright>Copyright (c) 2019 Zym Labs LLC</Copyright>
+      <Copyright>Copyright (c) 2023 Zym Labs LLC</Copyright>
       <PackageLicenseUrl>https://raw.githubusercontent.com/zymlabs/nswag-fluentvalidation/master/LICENSE</PackageLicenseUrl>
       <RepositoryUrl>https://github.com/zymlabs/nswag-fluentvalidation.git</RepositoryUrl>
       <RepositoryType>git</RepositoryType>
       <PackageTags>nswag; fluentvalidation; swagger; aspnetcore</PackageTags>
-      <LangVersion>8</LangVersion>
+      <LangVersion>10</LangVersion>
       <Nullable>enable</Nullable>
+      <GenerateDocumentationFile>true</GenerateDocumentationFile>
     </PropertyGroup>
+    
+    <ItemGroup>
+    </ItemGroup>
 
     <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
       <DocumentationFile>bin\Debug\ZymLabs.NSwag.FluentValidation.AspNetCore.xml</DocumentationFile>
@@ -21,9 +25,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="FluentValidation" Version="10.2.3" />
-      <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
-      <PackageReference Include="System.Text.Encodings.Web" Version="4.5.1" />
+      <FrameworkReference Include="Microsoft.AspNetCore.App" />
+      <PackageReference Include="System.Text.Encodings.Web" Version="8.0.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/ZymLabs.NSwag.FluentValidation/IgnoreAllStringComparer.cs
+++ b/src/ZymLabs.NSwag.FluentValidation/IgnoreAllStringComparer.cs
@@ -14,7 +14,7 @@ namespace ZymLabs.NSwag.FluentValidation
         public static readonly StringComparer Instance = new IgnoreAllStringComparer();
 
         /// <inheritdoc />
-        public override int Compare(string left, string right)
+        public override int Compare(string? left, string? right)
         {
             int leftIndex = 0;
             int rightIndex = 0;
@@ -35,7 +35,7 @@ namespace ZymLabs.NSwag.FluentValidation
         }
 
         /// <inheritdoc />
-        public override bool Equals(string left, string right)
+        public override bool Equals(string? left, string? right)
         {
             if (left == null || right == null)
                 return false;
@@ -74,20 +74,28 @@ namespace ZymLabs.NSwag.FluentValidation
             }
         }
 
-        internal static bool GetNextSymbol(string value, ref int startIndex, out char symbol)
+        internal static bool GetNextSymbol(string? value, ref int startIndex, out char symbol)
         {
+            symbol = char.MinValue;
+
+            if (value == null)
+            {
+                return false;
+            }
+            
             while (startIndex >= 0 && startIndex < value.Length)
             {
                 var current = value[startIndex++];
-                if (char.IsLetterOrDigit(current))
+                if (!char.IsLetterOrDigit(current))
                 {
-                    symbol = char.ToUpperInvariant(current);
-                    return true;
+                    continue;
                 }
+                
+                symbol = char.ToUpperInvariant(current);
+                return true;
             }
 
             startIndex = -1;
-            symbol = char.MinValue;
             return false;
         }
     }

--- a/src/ZymLabs.NSwag.FluentValidation/ValidationExtensions.cs
+++ b/src/ZymLabs.NSwag.FluentValidation/ValidationExtensions.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using FluentValidation;
-using FluentValidation.Internal;
 using FluentValidation.Validators;
 
 namespace ZymLabs.NSwag.FluentValidation

--- a/src/ZymLabs.NSwag.FluentValidation/ZymLabs.NSwag.FluentValidation.csproj
+++ b/src/ZymLabs.NSwag.FluentValidation/ZymLabs.NSwag.FluentValidation.csproj
@@ -8,8 +8,9 @@
     <RepositoryUrl>https://github.com/zymlabs/nswag-fluentvalidation.git</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>nswag; fluentvalidation; swagger</PackageTags>
-    <LangVersion>9</LangVersion>
+    <LangVersion>10</LangVersion>
     <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
@@ -22,9 +23,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentValidation" Version="10.2.3" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0" />
-    <PackageReference Include="NJsonSchema" Version="10.4.4" />
+    <PackageReference Include="FluentValidation" Version="[11.0.0,)" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
+    <PackageReference Include="NJsonSchema" Version="[11.0.0-preview006,)" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
There are assembly errors when referencing this project with FluentValidation 11.x since this project targets 10.2.3. It is possible that these version constraints are more strict than they need to be. But I haven't tested <11.0.

Also updated the AspNetCore project references to remove deprecated dependencies.