### PR TITLE
Add support for inheritance

### DIFF
--- a/src/ZymLabs.NSwag.FluentValidation.AspNetCore/HttpContextServiceProviderValidatorFactory.cs
+++ b/src/ZymLabs.NSwag.FluentValidation.AspNetCore/HttpContextServiceProviderValidatorFactory.cs
@@ -8,6 +8,7 @@ namespace ZymLabs.NSwag.FluentValidation.AspNetCore
     /// Allows for the creation of validators that have dependencies on scoped services.
     /// <see href="https://github.com/micro-elements/MicroElements.Swashbuckle.FluentValidation/blob/master/src/MicroElements.Swashbuckle.FluentValidation/HttpContextServiceProviderValidatorFactory.cs"/>
     /// </summary>
+    [Obsolete]
     public class HttpContextServiceProviderValidatorFactory : ValidatorFactoryBase
     {
         private readonly IHttpContextAccessor _httpContextAccessor;

--- a/src/ZymLabs.NSwag.FluentValidation.AspNetCore/ZymLabs.NSwag.FluentValidation.AspNetCore.csproj
+++ b/src/ZymLabs.NSwag.FluentValidation.AspNetCore/ZymLabs.NSwag.FluentValidation.AspNetCore.csproj
@@ -12,9 +12,6 @@
       <Nullable>enable</Nullable>
       <GenerateDocumentationFile>true</GenerateDocumentationFile>
     </PropertyGroup>
-    
-    <ItemGroup>
-    </ItemGroup>
 
     <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
       <DocumentationFile>bin\Debug\ZymLabs.NSwag.FluentValidation.AspNetCore.xml</DocumentationFile>
@@ -26,7 +23,7 @@
 
     <ItemGroup>
       <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
-      <PackageReference Include="System.Text.Encodings.Web" Version="8.0.0" />
+      <PackageReference Include="System.Text.Encodings.Web" Version="9.0.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/ZymLabs.NSwag.FluentValidation/RuleContext.cs
+++ b/src/ZymLabs.NSwag.FluentValidation/RuleContext.cs
@@ -1,4 +1,5 @@
 using FluentValidation.Validators;
+using NJsonSchema;
 using NJsonSchema.Generation;
 
 namespace ZymLabs.NSwag.FluentValidation
@@ -14,6 +15,11 @@ namespace ZymLabs.NSwag.FluentValidation
         public SchemaProcessorContext SchemaProcessorContext { get; }
 
         /// <summary>
+        /// Schema to process.
+        /// </summary>
+        public JsonSchema Schema { get; }
+
+        /// <summary>
         /// Property name.
         /// </summary>
         public string PropertyKey { get; }
@@ -27,11 +33,13 @@ namespace ZymLabs.NSwag.FluentValidation
         /// Creates new instance of <see cref="RuleContext"/>.
         /// </summary>
         /// <param name="schemaProcessorContext">SchemaProcessorContext.</param>
+        /// <param name="schema">Schema to process.</param>
         /// <param name="propertyKey">Property name.</param>
         /// <param name="propertyValidator">Property validator.</param>
-        public RuleContext(SchemaProcessorContext schemaProcessorContext, string propertyKey, IPropertyValidator propertyValidator)
+        public RuleContext(SchemaProcessorContext schemaProcessorContext, JsonSchema schema, string propertyKey, IPropertyValidator propertyValidator)
         {
             SchemaProcessorContext = schemaProcessorContext;
+            Schema = schema;
             PropertyKey = propertyKey;
             PropertyValidator = propertyValidator;
         }

--- a/src/ZymLabs.NSwag.FluentValidation/ZymLabs.NSwag.FluentValidation.csproj
+++ b/src/ZymLabs.NSwag.FluentValidation/ZymLabs.NSwag.FluentValidation.csproj
@@ -23,9 +23,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentValidation" Version="[11.0.0,)" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
-    <PackageReference Include="NJsonSchema" Version="[11.0.0-preview006,)" />
+    <PackageReference Include="FluentValidation" Version="11.11.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0" />
+    <PackageReference Include="NJsonSchema" Version="11.1.0" />
   </ItemGroup>
 
 </Project>

--- a/tests/ZymLabs.NSwag.FluentValidation.AspNetCore.Tests/HttpContextServiceProviderValidationFactoryTest.cs
+++ b/tests/ZymLabs.NSwag.FluentValidation.AspNetCore.Tests/HttpContextServiceProviderValidationFactoryTest.cs
@@ -1,6 +1,5 @@
 using System;
 using FluentValidation;
-using FluentValidation.Validators;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Moq;
@@ -8,6 +7,7 @@ using Xunit;
 
 namespace ZymLabs.NSwag.FluentValidation.AspNetCore.Tests
 {
+    [Obsolete]
     public class HttpContextServiceProviderValidationFactoryTest
     {
         [Fact]

--- a/tests/ZymLabs.NSwag.FluentValidation.AspNetCore.Tests/TestValidator.cs
+++ b/tests/ZymLabs.NSwag.FluentValidation.AspNetCore.Tests/TestValidator.cs
@@ -1,7 +1,9 @@
+using System;
 using FluentValidation;
 
 namespace ZymLabs.NSwag.FluentValidation.AspNetCore.Tests
 {
+    [Obsolete]
     public class TestValidator : AbstractValidator<HttpContextServiceProviderValidatorFactory>
     {
         

--- a/tests/ZymLabs.NSwag.FluentValidation.AspNetCore.Tests/TestWebApplicationFactory.cs
+++ b/tests/ZymLabs.NSwag.FluentValidation.AspNetCore.Tests/TestWebApplicationFactory.cs
@@ -1,8 +1,5 @@
 using System;
-using System.Collections.Generic;
 using System.Net.Http;
-using System.Security.Claims;
-using System.Threading.Tasks;
 using FluentValidation.AspNetCore;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
@@ -11,6 +8,7 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace ZymLabs.NSwag.FluentValidation.AspNetCore.Tests
 {
+    [Obsolete]
     public class TestWebApplicationFactory<TStartup> : WebApplicationFactory<TStartup> where TStartup : class
     {
         protected override void ConfigureWebHost(IWebHostBuilder builder)

--- a/tests/ZymLabs.NSwag.FluentValidation.AspNetCore.Tests/ZymLabs.NSwag.FluentValidation.AspNetCore.Tests.csproj
+++ b/tests/ZymLabs.NSwag.FluentValidation.AspNetCore.Tests/ZymLabs.NSwag.FluentValidation.AspNetCore.Tests.csproj
@@ -10,20 +10,13 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="FluentValidation.AspNetCore" Version="10.2.3" />
-        <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="5.0.6" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
-        <PackageReference Include="Moq" Version="4.16.1" />
-        <PackageReference Include="xunit" Version="2.4.1" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
-          <PrivateAssets>all</PrivateAssets>
-          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="3.0.3">
-          <PrivateAssets>all</PrivateAssets>
-          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
+        <PackageReference Include="FluentValidation.AspNetCore" Version="11.3.0" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.11" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+        <PackageReference Include="Moq" Version="4.20.72" />
+        <PackageReference Include="xunit" Version="2.9.2" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" PrivateAssets="all" />
+        <PackageReference Include="coverlet.collector" Version="6.0.2" PrivateAssets="all" />
     </ItemGroup>
 
     <ItemGroup>

--- a/tests/ZymLabs.NSwag.FluentValidation.Tests/FluentValidationSchemaProcessorTest.cs
+++ b/tests/ZymLabs.NSwag.FluentValidation.Tests/FluentValidationSchemaProcessorTest.cs
@@ -33,7 +33,7 @@ namespace ZymLabs.NSwag.FluentValidation.Tests
             var schema = JsonSchema.FromType<MockValidationTarget>(jsonSchemaGeneratorSettings);
 
             // Assert
-            Assert.NotEmpty(schema.Properties["EmailAddress"].Pattern);
+            Assert.NotEmpty(schema.Properties["EmailAddress"].Pattern!);
         }
         
         [Fact]
@@ -46,7 +46,7 @@ namespace ZymLabs.NSwag.FluentValidation.Tests
             var schema = JsonSchema.FromType<MockValidationTarget>(jsonSchemaGeneratorSettings);
 
             // Assert
-            Assert.NotEmpty(schema.Properties["EmailAddress"].Pattern);
+            Assert.NotEmpty(schema.Properties["EmailAddress"].Pattern!);
         }
 
         [Fact]
@@ -193,33 +193,34 @@ namespace ZymLabs.NSwag.FluentValidation.Tests
             Assert.Contains("NotNull", schema.RequiredProperties);
             Assert.Equal(1, schema.Properties["NotEmpty"].MinLength);
         }
-        
-        // [Fact]
-        // public void ProcessIncludesDefaultRuleNotEmptyOnTargetClassExtended()
-        // {
-        //     // Arrange
-        //     var jsonSchemaGeneratorSettings = CreateJsonSchemaGeneratorSettingsExtended();
 
-        //     // Act
-        //     var schema = JsonSchema.FromType<MockValidationTargetExtended>(jsonSchemaGeneratorSettings);
+        [Fact]
+        public void ProcessIncludesDefaultRuleNotEmptyOnTargetClassExtended()
+        {
+            // Arrange
+            var jsonSchemaGeneratorSettings = CreateJsonSchemaGeneratorSettingsExtended();
 
-        //     // Assert
-        //     // Assert.Equal(1, schema.Properties["ChildProperty"].MinLength);
-        //     // Assert.False(schema.Properties["ChildProperty"].IsNullable(SchemaType.OpenApi3));
+            // Act
+            var schema = JsonSchema.FromType<MockValidationTargetExtended>(jsonSchemaGeneratorSettings);
 
-        //     Assert.Equal(1, schema.Properties["NotEmpty"].MinLength);
-        //     Assert.False(schema.Properties["NotEmpty"].IsNullable(SchemaType.OpenApi3));
-            
-        //     var notEmptyChildProperty = schema.Properties["NotEmptyChild"];
-        //     Assert.Empty(notEmptyChildProperty.OneOf);
-        //     Assert.NotNull(notEmptyChildProperty.Reference);
-            
-        //     // Unable to get this to work right now
-        //     // var notEmptyChildPropertyEnum = schema.Properties["NotEmptyChildEnum"];
-        //     // Assert.Empty(notEmptyChildPropertyEnum.OneOf);
-        //     // Assert.NotNull(notEmptyChildPropertyEnum.Reference);
-        // }
-        
+            // Assert
+            var extendedProperty = schema.ActualProperties["ExtendedProperty"];
+            Assert.Equal(1, extendedProperty.MinLength);
+            Assert.False(extendedProperty.IsNullable(SchemaType.OpenApi3));
+
+            var inheritedNotEmptyProperty = schema.InheritedSchema!.Properties["NotEmpty"];
+            Assert.Equal(1, inheritedNotEmptyProperty.MinLength);
+            Assert.False(inheritedNotEmptyProperty.IsNullable(SchemaType.OpenApi3));
+
+            var inheritedNotEmptyChildProperty = schema.InheritedSchema.Properties["NotEmptyChild"];
+            Assert.Empty(inheritedNotEmptyChildProperty.OneOf);
+            Assert.NotNull(inheritedNotEmptyChildProperty.Reference);
+
+            var inheritedNotEmptyChildPropertyEnum = schema.InheritedSchema.Properties["NotEmptyChildEnum"];
+            Assert.Empty(inheritedNotEmptyChildPropertyEnum.OneOf);
+            Assert.NotNull(inheritedNotEmptyChildPropertyEnum.Reference);
+        }
+
         private JsonSchemaGeneratorSettings CreateJsonSchemaGeneratorSettings()
         {
             var testValidator = new MockValidationTargetValidator();

--- a/tests/ZymLabs.NSwag.FluentValidation.Tests/MockValidationTargetExtended.cs
+++ b/tests/ZymLabs.NSwag.FluentValidation.Tests/MockValidationTargetExtended.cs
@@ -2,6 +2,6 @@ namespace ZymLabs.NSwag.FluentValidation.Tests
 {
     public class MockValidationTargetExtended : MockValidationTarget
     {
-        public string ChildProperty = "";
+        public string ExtendedProperty { get; set; } = "";
     }
 }

--- a/tests/ZymLabs.NSwag.FluentValidation.Tests/MockValidationTargetExtendedValidator.cs
+++ b/tests/ZymLabs.NSwag.FluentValidation.Tests/MockValidationTargetExtendedValidator.cs
@@ -7,7 +7,7 @@ namespace ZymLabs.NSwag.FluentValidation.Tests
         /// <inheritdoc />
         public MockValidationTargetExtendedValidator()
         {
-            // RuleFor(sample => sample.ChildProperty).NotEmpty();
+            RuleFor(sample => sample.ExtendedProperty).NotEmpty();
             RuleFor(sample => sample.NotEmpty).NotEmpty();
         }
     }

--- a/tests/ZymLabs.NSwag.FluentValidation.Tests/ZymLabs.NSwag.FluentValidation.Tests.csproj
+++ b/tests/ZymLabs.NSwag.FluentValidation.Tests/ZymLabs.NSwag.FluentValidation.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <LangVersion>8</LangVersion>
@@ -7,14 +7,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
-    <PackageReference Include="Moq" Version="4.16.1" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.console" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.console" Version="2.9.2" PrivateAssets="all" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
(I made your test work ;-))

This is probably a breaking change for people that created custom FluentValidationRules, as I changed the RuleContext.

Because we have to recursively go through all the inherited schemas, the "Apply" method of FluentValidationRule will now be called for each individual schema, so I had to add that schema to the RuleContext (otherwise the rules themselves would have to do that recursion, which seems not the right way to handle this).

I also changed all the existing rules so they now look at "context.Schema" instead of "context.SchemaProcessorContext.Schema". Not sure if we still need to pass the schemaProcessorContext... there's none of the built in rules that depend on it... of course custom ones might... but maybe it would be good that they would break, as implementers of FluentValidationRules now also need to look at "context.Schema" iso "context.SchemaProcessorContext.Schema" to make it work with inheritance (and otherwise the apply method will be called multiple times but will always do the same work).

I also updated the packages (there was a "package with vulnerability" warning), and also got rid of the other warnings.